### PR TITLE
Deploy test, preprod and production environments for dra-dqt-notifications

### DIFF
--- a/.github/workflows/build-and-deploy-notifications.yml
+++ b/.github/workflows/build-and-deploy-notifications.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [dev] #[dev, test, preprod, production]
+        environment: [dev, test, preprod, production]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .terraform
+bin/fetch_config.rb

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -7,11 +7,13 @@ locals {
 }
 
 resource "azurerm_service_plan" "app_service_plan" {
-  name                = local.app_service_plan_name
-  location            = data.azurerm_resource_group.resource_group.location
-  resource_group_name = data.azurerm_resource_group.resource_group.name
-  os_type             = "Linux"
-  sku_name            = "B1"
+  name                   = local.app_service_plan_name
+  location               = data.azurerm_resource_group.resource_group.location
+  resource_group_name    = data.azurerm_resource_group.resource_group.name
+  os_type                = "Linux"
+  sku_name               = var.app_service_plan_sku_size
+  zone_balancing_enabled = var.worker_count != null ? true : false
+  worker_count           = var.worker_count
   lifecycle {
     ignore_changes = [
       tags
@@ -24,8 +26,8 @@ resource "azurerm_linux_function_app" "function_app" {
   location                   = data.azurerm_resource_group.resource_group.location
   resource_group_name        = data.azurerm_resource_group.resource_group.name
   service_plan_id            = azurerm_service_plan.app_service_plan.id
-  storage_account_name       = azurerm_storage_account.storage_account.name
-  storage_account_access_key = azurerm_storage_account.storage_account.primary_access_key
+  storage_account_name       = azurerm_storage_account.notify.name
+  storage_account_access_key = azurerm_storage_account.notify.primary_access_key
 
   app_settings = local.dqtnoti_env_vars
 
@@ -63,31 +65,6 @@ resource "azurerm_servicebus_topic" "servicebus_topic" {
   name                = local.servicebus_topic_name
   namespace_id        = azurerm_servicebus_namespace.servicebus_namespace.id
   enable_partitioning = true
-}
-
-resource "azurerm_storage_account" "storage_account" {
-  name                              = local.storage_account
-  resource_group_name               = data.azurerm_resource_group.resource_group.name
-  location                          = data.azurerm_resource_group.resource_group.location
-  account_tier                      = "Standard"
-  account_replication_type          = var.environment_name != "dev" ? "LRS" : "GRS"
-  account_kind                      = "StorageV2"
-  min_tls_version                   = "TLS1_2"
-  infrastructure_encryption_enabled = true
-
-  blob_properties {
-    last_access_time_enabled = true
-
-    container_delete_retention_policy {
-      days = var.data_protection_container_delete_retention_days
-    }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
 }
 
 resource "azurerm_mssql_server" "mssql_server" {

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,0 +1,25 @@
+resource "azurerm_storage_account" "notify" {
+  name                              = var.notify_storage_account_name
+  resource_group_name               = data.azurerm_resource_group.resource_group.name
+  location                          = data.azurerm_resource_group.resource_group.location
+  account_tier                      = "Standard"
+  account_replication_type          = var.environment_name != "dev" ? "LRS" : "GRS"
+  account_kind                      = "StorageV2"
+  min_tls_version                   = "TLS1_2"
+  infrastructure_encryption_enabled = true
+
+
+  blob_properties {
+    last_access_time_enabled = true
+
+    container_delete_retention_policy {
+      days = var.data_protection_container_delete_retention_days
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,7 +30,16 @@ variable "azure_sp_credentials_json" {
   default = null
 }
 
+variable "enable_blue_green" {
+  type    = bool
+  default = false
+}
+
 variable "resource_group_name" {
+  type = string
+}
+
+variable "notify_storage_account_name" {
   type = string
 }
 
@@ -66,11 +75,16 @@ variable "application_insights_retention_days" {
   default = 30
 }
 
+variable "worker_count" {
+  description = "It should be set to a multiple of the number of availability zones in the region"
+  type        = number
+  default     = null
+}
+
 locals {
   hosting_environment       = var.environment_name
   servicebus_namespace_name = "${var.resource_prefix}-dqtnoti-${var.environment_name}-sbn"
   servicebus_topic_name     = "${var.resource_prefix}-dqtnoti-${var.environment_name}-sbt"
-  storage_account           = "${var.resource_prefix}dqtnoti${var.environment_name}sg"
   app_service_plan_name     = "${var.resource_prefix}-dqtnoti-${var.environment_name}-spl"
   linux_function_app_name   = "${var.resource_prefix}-dqtnoti-${var.environment_name}-fapp"
   mssql_server              = "${var.resource_prefix}-dqtnoti-${var.environment_name}-mssql"

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -2,5 +2,7 @@
   "environment_name": "dev",
   "key_vault_name": "s165d01-dqtnoti-dv-kv",
   "resource_group_name": "s165d01-dqtnoti-dv-rg",
-  "resource_prefix": "s165d01"
+  "resource_prefix": "s165d01",
+  "enable_blue_green": false,
+  "notify_storage_account_name": "s165d01dqtnotidv"
 }

--- a/terraform/workspace_variables/preprod.backend.tfvars
+++ b/terraform/workspace_variables/preprod.backend.tfvars
@@ -1,0 +1,3 @@
+storage_account_name = "s165t01dqtnotitfstatepp"
+key                  = "preprod.tfstate"
+resource_group_name  = "s165t01-dqtnoti-pp-rg"

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -1,0 +1,11 @@
+{
+  "environment_name": "preprod",
+  "key_vault_name": "s165t01-dqtnoti-pp-kv",
+  "resource_group_name": "s165t01-dqtnoti-pp-rg",
+  "storage_account_name": "s165t01dqtnotitfstatepp",
+  "resource_prefix": "s165t01",
+  "enable_blue_green": true,
+  "app_service_plan_sku_size": "P1v2",
+  "worker_count": 3,
+  "notify_storage_account_name": "s165d01dqtnotipp"
+}

--- a/terraform/workspace_variables/production.backend.tfvars
+++ b/terraform/workspace_variables/production.backend.tfvars
@@ -1,0 +1,3 @@
+storage_account_name = "s165p01dqtnotitfstatepd"
+key                  = "production.tfstate"
+resource_group_name  = "s165p01-dqtnoti-pd-rg"

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -1,0 +1,11 @@
+{
+  "environment_name": "production",
+  "key_vault_name": "s165p01-dqtnoti-pd-kv",
+  "resource_group_name": "s165p01-dqtnoti-pd-rg",
+  "storage_account_name": "s165p01dqtnotitfstatepd",
+  "resource_prefix": "s165p01",
+  "enable_blue_green": true,
+  "app_service_plan_sku_size": "P1v2",
+  "worker_count": 3,
+  "notify_storage_account_name": "s165d01dqtnotipd"
+}

--- a/terraform/workspace_variables/test.backend.tfvars
+++ b/terraform/workspace_variables/test.backend.tfvars
@@ -1,0 +1,3 @@
+storage_account_name = "s165t01dqtnotitfstatets"
+key                  = "test.tfstate"
+resource_group_name  = "s165t01-dqtnoti-ts-rg"

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -1,0 +1,10 @@
+{
+  "environment_name": "test",
+  "key_vault_name": "s165t01-dqtnoti-ts-kv",
+  "resource_group_name": "s165t01-dqtnoti-ts-rg",
+  "storage_account_name": "s165t01dqtnotitfstatets",
+  "resource_prefix": "s165t01",
+  "enable_blue_green": true,
+  "app_service_plan_sku_size": "S1",
+  "notify_storage_account_name": "s165d01dqtnotits"
+}


### PR DESCRIPTION
Deployment of dra-dqt-notification to test, preprod and production environments.
Added additional app service plan instance for preprod and production.
All the environment implementations are successful.

Dev: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/9816b7b0-58ca-4972-b25b-c7dbd3ee1c6d/resourceGroups/s165d01-dqtnoti-dv-rg/overview
Test: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/250ff557-239a-4d89-83a4-07bdfc6218c7/resourceGroups/s165t01-dqtnoti-ts-rg/overview
Preprod: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/250ff557-239a-4d89-83a4-07bdfc6218c7/resourceGroups/s165t01-dqtnoti-pp-rg/overview
Production: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/9c2dcb72-4bba-4acc-8d5f-8b8389a68238/resourceGroups/s165p01-dqtnoti-pd-rg/overview

