### PR TITLE
Removed blue green and update the notify-storage-account name from d …

### DIFF
--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -3,6 +3,5 @@
   "key_vault_name": "s165d01-dqtnoti-dv-kv",
   "resource_group_name": "s165d01-dqtnoti-dv-rg",
   "resource_prefix": "s165d01",
-  "enable_blue_green": false,
   "notify_storage_account_name": "s165d01dqtnotidv"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -4,8 +4,7 @@
   "resource_group_name": "s165t01-dqtnoti-pp-rg",
   "storage_account_name": "s165t01dqtnotitfstatepp",
   "resource_prefix": "s165t01",
-  "enable_blue_green": true,
   "app_service_plan_sku_size": "P1v2",
   "worker_count": 3,
-  "notify_storage_account_name": "s165d01dqtnotipp"
+  "notify_storage_account_name": "s165t01dqtnotipp"
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -4,8 +4,7 @@
   "resource_group_name": "s165p01-dqtnoti-pd-rg",
   "storage_account_name": "s165p01dqtnotitfstatepd",
   "resource_prefix": "s165p01",
-  "enable_blue_green": true,
   "app_service_plan_sku_size": "P1v2",
   "worker_count": 3,
-  "notify_storage_account_name": "s165d01dqtnotipd"
+  "notify_storage_account_name": "s165p01dqtnotipd"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -4,7 +4,6 @@
   "resource_group_name": "s165t01-dqtnoti-ts-rg",
   "storage_account_name": "s165t01dqtnotitfstatets",
   "resource_prefix": "s165t01",
-  "enable_blue_green": true,
   "app_service_plan_sku_size": "S1",
-  "notify_storage_account_name": "s165d01dqtnotits"
+  "notify_storage_account_name": "s165t01dqtnotits"
 }


### PR DESCRIPTION
Removed blue/green from dev, test, pre-prod and prod environments.
Modified notify_storage_account_name for the test, pre-prod and prod environments,i.e., d01 to t01 and po1 for test, pre-prod and production environments.
All the environments deployed successfully