### PR TITLE
Add service principal check

### DIFF
--- a/.github/workflows/check-sp.yml
+++ b/.github/workflows/check-sp.yml
@@ -1,0 +1,71 @@
+name: Check Service Principal
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "35 6 * * *"
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.select-tests.outputs.tests }}
+    steps:
+      - name: Select Tests
+        id: select-tests
+        run: |
+          d="{'environment':'dev', 'principal': 's165d01-dqt-contributor', 'keyvault': 's165d01-dv-kv'}"
+          t="{'environment':'test', 'principal': 's165t01-dqt-contributor', 'keyvault': 's165t01-pp-kv'}"
+          p="{'environment':'production', 'principal': 's165p01-dqt-contributor', 'keyvault': 's165p01-pd-kv'}"
+          tests="{ 'data':[ ${d},  ${t},  ${p} ]}"
+          echo "tests=${tests}" >> $GITHUB_OUTPUT
+  check_expires:
+    name: ${{matrix.data.environment}}/${{ matrix.data.principal }}
+    needs: set-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.set-matrix.outputs.tests) }}
+    environment:
+      name: ${{ matrix.data.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ${{ steps.serviceprincipal.outputs.name }}
+        uses: DFE-Digital/github-actions/CheckServicePrincipal@master
+        id: pwsh_check_expire
+        with:
+          AzureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+          ServicePrincipal: ${{ matrix.data.principal }}
+          ExpiresWithinDays: 30
+
+      - name: Processing
+        run: echo "${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application}} expires in ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}} days"
+
+      - name: Check out the repo
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        uses: actions/checkout@v3
+
+      - uses: Azure/login@v1
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        id: keyvault-yaml-secret
+        with:
+          keyvault: ${{ matrix.data.keyvault }}
+          secret: MONITORING
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Slack Notification
+        if: fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: "#ff0000"
+          SLACK_TITLE: ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }} ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }}
+          SLACK_MESSAGE: |
+            The Service Principal ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }}
+            key ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }} is due to expire in ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}} days
+            Please follow the process in https://dfe-technical-guidance.london.cloudapps.digital/how-to/security/managing-secrets/#access-key-expiration to renew.
+          SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
**Context**

The workflows are dependent on Service Principals (SP) with secrets that are time-limited; therefore, we would check for the expiry of such secrets.

**Changes proposed in this pull request**

This workflow will check the date of expiry of the Service Principal in dev, test and production environments. The check will look for SP's that are expiring in less than 30 days and will trigger an alert in Slack

**Guidance to review**

Check logs for test run[ here](https://github.com/DFE-Digital/tra-dqt-notifications/actions/runs/3813576152)

**Checklist**

Attach to Trello card
Rebased main
Cleaned commit history